### PR TITLE
Add workflow files to manage releases

### DIFF
--- a/.github/docs/create-release-branch.md
+++ b/.github/docs/create-release-branch.md
@@ -1,0 +1,28 @@
+# Create Release Branch Workflow
+The [create-release-branch](../workflows/create-release-branch.yml) workflow was thinking to work with the [release-drafter](../workflows/release-drafter.yml) workflow to manage the creation of the release branch when you want to create release from release branch (release/v0.1.x). 
+
+## Inputs
+|Name|Description|Type|Required|
+|---|---|---|---|
+|N/A|N/A|N/A|N/A|
+
+## Outputs
+|Name|Description|
+|---|---|
+|N/A|N/A|
+
+## Considerations
+This workflow needs to be trigger once the release is published, it get the tag associated and create a release branch, it change the target branch for the release branch that was created, this is necessary to allow the release drafter work properly. 
+
+## Usage
+```yml
+name: Create Release Branch
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  create-release-branch:
+    uses: <org-or-username>/<repo>/.github/workflows/create-release-branch.yml@<branch-or-tag>
+```

--- a/.github/docs/release-drafter.md
+++ b/.github/docs/release-drafter.md
@@ -1,0 +1,42 @@
+# Release Drafter Workflow
+The [release-drafter](../workflows/release-drafter.yml) workflow automates the creation and management of release drafts on GitHub. If you want to use this workflow you need to provide a `release drafter config file`, this file has all the configuration, in this file you can specify the versioning, content of the changelog, categories, labels, etc.
+
+This workflow autolabel your pull request based on title and branch names.
+
+## Inputs
+|Name|Description|Type|Required|
+|---|---|---|---|
+|N/A|N/A|N/A|N/A|
+
+## Outputs
+|Name|Description|
+|---|---|
+|N/A|N/A|
+
+## Considerations
+If you want to create a release from default branch (main) you only need to provide the `.github/release-drafter-main.yml`, in case that you want to create a release from a release branch (release/v0.1.x) you need to provide the `.github/release-drafter-main.yml` and `.github/release-drafter-release.yml`. Also needs the [create-release-branch](../docs/create-release-branch.md) workflow to automates the creation of the release branch.
+
+You can find examples for [release-drafter-main.yml](../release-drafter-main.yml) and [release-drafter-release.yml](../release-drafter-release.yml) config files in this repository.
+
+This workflow is based in the [release-drafter action](https://github.com/release-drafter/release-drafter) for more information please follow the link.
+
+## Usage
+
+```yml
+name: Release Drafter # You can pick the name that make sense for you
+
+on:
+  push:
+    branches:
+      - main
+      - release/v** # Just in case that you want to create a release from release branches
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - release/v** # Just in case that you want to create a release from release branches
+
+jobs:
+  release-drafter:
+    uses: <org-or-username>/<repo>/.github/workflows/release-drafter.yml@<branch-or-tag>
+```

--- a/.github/release-drafter-main.yml
+++ b/.github/release-drafter-main.yml
@@ -1,0 +1,66 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: 💥 Breaking changes
+    labels:
+      - breaking
+  - title: '🚀 New features and improvements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '📖 Docs'
+    labels: 
+      - 'documentation'
+  - title: '📦 Dependencies updates'
+    labels:
+      - 'dependencies'
+  - title: '🚦 Tests'
+    labels:
+      - 'test'
+  - title: '🎲 Others'
+    labels:
+      - '*'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'security'
+      - 'maintenance'
+      - 'documentation'
+      - 'dependencies'
+      - 'test'
+      - 'chore'
+exclude-labels:
+  - 'skip-changelog'
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  For more details see the [full list of changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION/)

--- a/.github/release-drafter-release.yml
+++ b/.github/release-drafter-release.yml
@@ -1,0 +1,34 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+filter-by-commitish: true
+categories:
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+exclude-labels:
+  - 'skip-changelog'
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+      - '/hotfix\/.+/'
+      - '/bug\/.+/'
+      - '/bugfix\/.+/'
+    title:
+      - '/fix/i'
+      - '/hotfix/i'
+      - '/bug/i'
+      - '/bugfix/i'
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  For more details see the [full list of changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION/)

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -2,8 +2,6 @@ name: Create Release Branch
 
 on:
   workflow_call:
-  release:
-    types: [published]
 
 jobs:
   create-release-branch:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,27 @@
+name: Create Release Branch
+
+on:
+  workflow_call:
+  release:
+    types: [published]
+
+jobs:
+  create-release-branch:
+    permissions:
+        contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create branch
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}" # Output e.g. v0.1.0
+          BRANCH_NAME=$(echo "$TAG_NAME" | sed 's/\.[0-9]*$/\.x/') # Output e.g. v0.1.x
+          git checkout -b release/$BRANCH_NAME
+          git push origin release/$BRANCH_NAME
+          gh release edit $TAG_NAME --target release/$BRANCH_NAME
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,40 @@
+name: Release Drafter
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+      - release/v**
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - release/v**
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release drafter (Main)
+        if: ${{ github.ref_name == 'main' || github.base_ref == 'main' }}
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-main.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release drafter (Release)
+        if: ${{ contains(github.ref_name, 'release/v') || contains(github.base_ref, 'release/v') }}
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-release.yml
+          commitish: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Kevin Contreras
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# gh-workflows
+# GitHub Reusable Workflows
+This repository contains a collection of reusable and customizable GitHub workflows for automating various tasks in your software development process.
+
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Available Workflows](#available-workflows)
+- [Getting Started](#getting-started)
+- [Contributing](#contributing)
+- [FAQ](#faq)
+- [License](#license)
+
+
+## Introduction
+This repository provides a set of GitHub Actions workflows that can be easily incorporated into your project to automate tasks such as:
+- Continuous integration (CI): Building and testing your code on every push or pull request.
+- Continuous deployment (CD): Automatically deploying your application to production on successful CI builds.
+- Code coverage: Measuring the amount of code covered by tests.
+- Static code analysis: Detecting potential code issues early on.
+- Security scanning: Identifying vulnerabilities in your code.
+- Documentation generation: Automatically generating and updating documentation.
+And much more!
+
+
+## Available Workflows
+Here is a list of the currently available workflows in this repository:
+- [release-drafter](.github/docs/release-drafter.md): Create a release draft with all the information that you need (PR links, Contributors, Versioning, etc).
+- [create-release-branch](.github/docs/create-release-branch.md): This workflow create a release branch after a release is published, this is helpful in cases that you want to create releases from release branches (release/v0.1.x)
+
+
+## Getting Started
+To use the workflows in your repository, simply check the `*.md` files that are include in each workflow to learn how to use it. Make sure to configure any necessary secrets or environment variables.
+Helpful resources:
+- [GitHub Actions documentation](https://docs.github.com/actions)
+- [Creating workflows](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization)
+
+
+## Contributing
+We welcome contributions to this repository! If you have a new workflow you would like to share, please create a pull request.
+
+
+## FAQ
+
+### Cannot see my workflows?
+The workflow needs to be in the default branch otherwise doesn't appear in the actions menu and needs the following structure `.github/workflows/<file-name.yml>`.
+
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This pull request adds workflow files to manage releases. It includes the "Create Release Branch" workflow and the "Release Drafter" workflow. These workflows automate the creation and management of release branches and release drafts on GitHub. The "Create Release Branch" workflow creates a release branch when a release is published, and the "Release Drafter" workflow generates release drafts based on pull requests and commits.